### PR TITLE
Cordova add command fix for build 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $ cordova plugin add org.apache.cordova.geolocation
 $ cordova build ios
 $ cordova emulate ios
 ```
-To build, install cordova above version 4+
+To build, install latest cordova or above version 4+, then run
 
 ```bash
 $ cordova platform add ios

--- a/README.md
+++ b/README.md
@@ -13,7 +13,16 @@ $ cordova plugin add org.apache.cordova.geolocation
 $ cordova build ios
 $ cordova emulate ios
 ```
+To build, install cordova above version 4+
 
+```bash
+$ cordova platform add ios
+$ cordova plugin add cordova-plugin-device
+$ cordova plugin add cordova-plugin-statusbar
+$ cordova plugin add cordova-plugin-geolocation
+$ cordova build ios
+$ cordova emulate ios
+```
 Substitute ios for android above to test on Android.
 
 Created by [@maxlynch](http://twitter.com/maxlynch) for the [Ionic Framework](http://ionicframework.com/)


### PR DESCRIPTION
I faced issues with the command 'cordova plugin add org.apache.cordova.device' Then, came to know cordova plugin repository had been moved to npm from Apcahe server. Hence, I found a command syntax had been updated long ago. I am submitting fixes so other would not struggle to build the app.
